### PR TITLE
Add Advent of Code 2024 landing page

### DIFF
--- a/_projects/advent_of_code24.md
+++ b/_projects/advent_of_code24.md
@@ -1,0 +1,13 @@
+---
+layout: nested
+title: Advent of Code 2024
+description: Explanations to my Advent of Code 2024 solutions
+files:
+  - 'day_1'
+---
+
+# [**Advent of Code 2024**](https://adventofcode.com/2024)
+
+`Advent of Code is an Advent calendar of small programming puzzles for a variety of skill sets and skill levels that can be solved in any programming language you like. People use them as interview prep, company training, university coursework, practice problems, a speed contest, or to challenge each other.`
+
+The pages found below document my solutions to the 2024 Advent of Code puzzles written in Python. These pages describe the problems, discuss my thought process, and detail my solutions to them. Within each page I also provide a critique of my solution in terms of computational efficiency and software quality.


### PR DESCRIPTION
This PR adds the landing page for Advent of Code 2024 solutions. The new page follows the same format as the 2023 landing page but:

- Only includes day_1 in the files list since that's the only solution documented so far
- Omits the "Most Interesting Problems" table as it's too early to determine those
- Maintains the same introductory text explaining what Advent of Code is

Closes #4